### PR TITLE
Rename project to forbid-junk-object-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# check-single-use-types
+# forbid-junk-object-types
 
 A TypeScript linter that detects object types and interfaces used by only a single function. This helps identify cases where developers create generic wrapper types that don't describe actual domain concepts, often to work around ESLint's `max-params` rule.
 
@@ -33,11 +33,11 @@ This tool:
 ## Installation
 
 ```bash
-npm install check-single-use-types
+npm install forbid-junk-object-types
 # or
-pnpm add check-single-use-types
+pnpm add forbid-junk-object-types
 # or
-yarn add check-single-use-types
+yarn add forbid-junk-object-types
 ```
 
 ## Usage
@@ -46,19 +46,19 @@ yarn add check-single-use-types
 
 ```bash
 # Check all files in current directory
-npx check-single-use-types
+npx forbid-junk-object-types
 
 # Check specific directory
-npx check-single-use-types --target-dir ./src
+npx forbid-junk-object-types --target-dir ./src
 
 # Check only changed files (for CI)
-npx check-single-use-types --changed-only
+npx forbid-junk-object-types --changed-only
 
 # Generate suppressions for all violations
-npx check-single-use-types --suppress-all
+npx forbid-junk-object-types --suppress-all
 
 # Check specific files
-npx check-single-use-types --files src/foo.ts src/bar.ts
+npx forbid-junk-object-types --files src/foo.ts src/bar.ts
 ```
 
 ### NPM Scripts
@@ -68,8 +68,8 @@ Add to your `package.json`:
 ```json
 {
   "scripts": {
-    "check-types": "check-single-use-types",
-    "check-types:changed": "check-single-use-types --changed-only"
+    "check-types": "forbid-junk-object-types",
+    "check-types:changed": "forbid-junk-object-types --changed-only"
   }
 }
 ```
@@ -84,7 +84,7 @@ Add to your `package.json`:
 
 ## Suppression Mechanism
 
-Suppressions are stored in `<target-dir>/single-use-types-suppressions.json`:
+Suppressions are stored in `<target-dir>/junk-object-types-suppressions.json`:
 
 ```json
 {
@@ -121,7 +121,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  single-use-types:
+  junk-object-types:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -131,8 +131,8 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - name: Check for single-use types (changed files only)
-        run: npx check-single-use-types --changed-only
+      - name: Check for junk object types (changed files only)
+        run: npx forbid-junk-object-types --changed-only
 ```
 
 ### Other CI Systems

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "check-single-use-types",
+  "name": "forbid-junk-object-types",
   "version": "1.0.0",
   "description": "TypeScript linter that detects object types and interfaces used by only a single function",
   "main": "./dist/index.js",
   "type": "module",
   "bin": {
-    "check-single-use-types": "./dist/index.js"
+    "forbid-junk-object-types": "./dist/index.js"
   },
   "exports": {
     ".": {
@@ -44,12 +44,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fhwang/check-single-use-types.git"
+    "url": "https://github.com/fhwang/forbid-junk-object-types.git"
   },
   "bugs": {
-    "url": "https://github.com/fhwang/check-single-use-types/issues"
+    "url": "https://github.com/fhwang/forbid-junk-object-types/issues"
   },
-  "homepage": "https://github.com/fhwang/check-single-use-types#readme",
+  "homepage": "https://github.com/fhwang/forbid-junk-object-types#readme",
   "packageManager": "pnpm@10.19.0",
   "engines": {
     "node": ">=18.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,10 +85,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
 function printHelp(): void {
   console.log(`
-Single-use Type Linter
+Junk Object Type Linter
 
 Usage:
-  single-use-types [options]
+  forbid-junk-object-types [options]
 
 Options:
   --target-dir <path>    Directory to analyze (default: current directory)
@@ -98,10 +98,10 @@ Options:
   --help, -h            Show this help message
 
 Examples:
-  single-use-types --target-dir ./client
-  single-use-types --changed-only
-  single-use-types --suppress-all
-  single-use-types --files src/foo.ts src/bar.ts
+  forbid-junk-object-types --target-dir ./client
+  forbid-junk-object-types --changed-only
+  forbid-junk-object-types --suppress-all
+  forbid-junk-object-types --files src/foo.ts src/bar.ts
 `);
 }
 
@@ -180,7 +180,7 @@ function filterSuppressedViolations(
 
 async function runAnalysis(args: ParsedArgs): Promise<void> {
   const targetDir = args.targetDir;
-  const suppressionPath = path.join(targetDir, 'single-use-types-suppressions.json');
+  const suppressionPath = path.join(targetDir, 'junk-object-types-suppressions.json');
   const suppressions = loadSuppressions(suppressionPath);
   const filesToCheck = determineFilesToCheck(args, targetDir);
   const result = await analyzeCodebase({ targetDir, specificFiles: filesToCheck });


### PR DESCRIPTION
## Summary
- Rename package from `check-single-use-types` to `forbid-junk-object-types`
- Update binary command name
- Update all repository URLs (GitHub, bugs, homepage)
- Update CLI help text and examples
- Update README documentation
- Change suppression file name from `single-use-types-suppressions.json` to `junk-object-types-suppressions.json`

## Test plan
- [x] `pnpm build` compiles successfully
- [x] `pnpm test:run` passes all 18 tests
- [x] CLI `--help` shows new name correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)