### PR TITLE
Fix: handle TypeLiteral nodes in extractAllTypeNames

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forbid-junk-object-types",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "TypeScript linter that detects object types and interfaces used by only a single function",
   "main": "./dist/index.js",
   "type": "module",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,6 +42,11 @@ function extractAllTypeNames(typeNode: ts.TypeNode | undefined): string[] {
   if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
     return typeNode.types.flatMap(extractAllTypeNames);
   }
+  if (ts.isTypeLiteralNode(typeNode)) {
+    return typeNode.members
+      .filter((m): m is ts.PropertySignature => ts.isPropertySignature(m) && !!m.type)
+      .flatMap(m => extractAllTypeNames(m.type));
+  }
   return [];
 }
 

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -189,6 +189,16 @@ describe('analyzer', () => {
     expect(typeNames).not.toContain('ApiSubscription');
   });
 
+  it('does not flag types used as a property in an inline object parameter type', async () => {
+    const result = await analyzeCodebase({
+      targetDir: fixturesDir,
+      specificFiles: [path.join(fixturesDir, 'src/inline-param-type-usage.ts')],
+    });
+
+    const typeNames = result.violations.map(v => v.typeName);
+    expect(typeNames).not.toContain('OrderAndLineItemResult');
+  });
+
   it('defaults to target directory itself when no sourceDir and no src/ exists', async () => {
     const result = await analyzeCodebase({
       targetDir: fixturesNoSrcDir,

--- a/test/fixtures/src/inline-param-type-usage.ts
+++ b/test/fixtures/src/inline-param-type-usage.ts
@@ -1,0 +1,12 @@
+interface OrderAndLineItemResult {
+  orderId: string;
+  lineItemId: string;
+}
+
+function getOrderResult(): OrderAndLineItemResult {
+  return { orderId: '1', lineItemId: '2' };
+}
+
+function findOrderAndLineItem(params: { orderResult: OrderAndLineItemResult }) {
+  return params.orderResult;
+}

--- a/test/fixtures/src/inline-param-type-usage.ts
+++ b/test/fixtures/src/inline-param-type-usage.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 interface OrderAndLineItemResult {
   orderId: string;
   lineItemId: string;


### PR DESCRIPTION
## Summary
- Types used as properties within inline object parameter types (e.g., `params: { orderResult: SomeType }`) were not tracked as usages, causing false single-use violations
- Added `ts.isTypeLiteralNode` handling to `extractAllTypeNames` so property types within inline objects are recursively extracted
- Added test fixture and test case covering this pattern

## Test plan
- [x] All 40 existing + new tests pass via `pnpm test`
- [ ] Verify against real-world codebases with inline object parameter patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)