### PR TITLE
Expand fixing-violations.md with prioritized workflow and LLM guidance

### DIFF
--- a/docs/fixing-violations.md
+++ b/docs/fixing-violations.md
@@ -11,11 +11,71 @@ domain modeling, not just move code around.
 - Never just rename the type (e.g., `Options` -> `Config`). That doesn't fix the problem.
 - Never create a wrapper type without domain meaning just to satisfy the linter.
 - Never suppress without first trying the refactoring patterns below.
+- Never convert a named type to an inline object type. The fix for a single-use
+  named type is to restructure code so the type is used in multiple places or is
+  no longer needed -- not to inline it as an anonymous object type.
+
+## Working with other linting rules
+
+This linter is often used alongside ESLint rules like `max-params`,
+`max-lines-per-function`, and similar structural checks. Fixes must satisfy all
+rules simultaneously -- don't fix a junk-object-type violation by creating a new
+`max-params` violation (e.g., replacing a parameter object with 10 individual
+parameters).
+
+The goal is better domain modeling. When a straightforward fix would break another
+rule, that's a signal to restructure more deeply: split the function, share types
+across boundaries, or rethink the abstraction.
+
+## Workflow: fixing single-use type violations
+
+When you encounter a single-use type violation, work through these steps in order.
+Earlier steps are simpler and more common.
+
+### Step 1: Delete unused code
+
+Check if the function that uses this type is actually called anywhere:
+- Search for imports and call sites across the codebase
+- If the function is unused, delete it and its types
+- Exported-but-never-imported functions are dead code -- delete them
+- An export is only "public" if it's re-exported from a package entry point;
+  internal exports with no callers are still safe to delete
+
+### Step 2: Consider inlining the helper into its single caller
+
+If the function has exactly one caller, consider inlining the function body.
+This eliminates the parameter bundle type naturally. However, inlining may make
+the caller too large -- that's OK as a temporary step. Once the logic is back in
+the caller, you may find a better boundary for re-extraction that doesn't require
+a single-use parameter type.
+
+Keep the helper as-is if it has 2+ callers or contains complex logic worth
+isolating. If the function is exported, check whether it's part of the package's
+public API (re-exported from an entry point or index file) or just exported for
+use within the same package. Internal exports with a single caller can still be
+inlined.
+
+### Step 3: Consolidate types across function boundaries
+
+Look for opportunities to share types between related functions:
+- If function A calls function B and passes a subset of its parameters, extract
+  a shared type for the common parameters
+- Use intersection types (`&`) to extend shared types with additional fields
+- If multiple functions read/write the same state, reuse the state type instead
+  of creating parameter types that duplicate its fields
+
+### Step 4: Other strategies
+
+- Nest types as subdomains when fields have semantic cohesion
+- Combine pipeline functions when an intermediate type only connects two functions
+- Unify parallel data structures into cohesive domain objects
+- Check external packages for existing type definitions before creating stubs
 
 ## When you see: "X is only used by function 'Y'"
 
 This means a named type (interface or type alias) exists but is only referenced by
-one function. Ask yourself what's going on:
+one function. The patterns below correspond to the workflow steps above -- try
+deletion and inlining first.
 
 **Can this type be eliminated entirely?**
 
@@ -156,3 +216,30 @@ function updateOrder(params: {
 function completeOrderItem(order: Order, itemId: string) { ... }
 function completeOrder(order: Order) { ... }
 ```
+
+## Naming types
+
+When extracting or consolidating types, name them after domain concepts -- what
+the data represents -- not after the function that uses them.
+
+Good names: `RetryPolicy`, `OrderBatchJob`, `CollectionSummary`
+Avoid: `FetchOptions`, `SubmitBatchParams`, `HandleResultConfig`
+
+Generic suffixes like `*Params`, `*Options`, `*Config`, and `*Context` often
+indicate the type was created to serve a function rather than to model the domain.
+If you can't find a domain-meaningful name, that may signal the type is bundling
+unrelated concerns.
+
+## Check external packages for existing types
+
+Before creating custom type definitions for external APIs or SDKs, check if the
+package already provides official types. This prevents single-use type violations
+and ensures type compatibility.
+
+Where to look:
+- Package TypeScript definitions: `node_modules/[package]/` for `.d.ts` files
+- Package subdirectories: `resources/`, `lib/`, `types/`
+- Import exploration: use IDE autocomplete to discover available types
+
+If you find an existing type, import it directly rather than creating a stub that
+duplicates its shape.

--- a/docs/plans/2026-02-25-expand-fixing-violations-hints-design.md
+++ b/docs/plans/2026-02-25-expand-fixing-violations-hints-design.md
@@ -1,0 +1,85 @@
+# Design: Expand fixing-violations.md with LLM guidance
+
+## Problem
+
+A user reported needing to add ~20KB of supplemental guidance to their CLAUDE.md
+to get Claude Code to correctly fix violations reported by this linter. The main
+failure modes were:
+
+1. Claude Code defaulting to inlining types (converting named types to anonymous
+   inline object types), which moves in the wrong direction
+2. No prioritized workflow — Claude Code would try complex refactorings before
+   checking if the code was unused or the helper could be inlined
+3. Fixes that resolved one violation but created new ESLint violations
+   (e.g., max-params)
+4. Creating types with generic names (`*Params`, `*Options`) instead of
+   domain-meaningful names
+
+## Approach
+
+Expand the existing `docs/fixing-violations.md` from ~159 lines to ~250-300
+lines. Keep the existing pattern sections (which are already good) and add:
+
+1. An anti-inlining warning in the "Never do these" section
+2. A "Working with other linting rules" section about satisfying all rules
+   simultaneously
+3. A prioritized workflow (DELETE → INLINE HELPER → CONSOLIDATE → OTHER)
+4. Type naming guidance
+5. External package type checking guidance
+
+Content is generalized from the user's codebase-specific examples to be
+universally applicable.
+
+## Detailed changes
+
+### "Never do these" — add one bullet
+
+Add: "Never convert a named type to an inline object type. The fix for a
+single-use named type is to restructure code so the type is used in multiple
+places or is no longer needed — not to inline it as an anonymous object type."
+
+### New section: "Working with other linting rules"
+
+This linter is often used alongside ESLint rules like `max-params`,
+`max-lines-per-function`, and similar structural checks. Fixes must satisfy
+all rules simultaneously. The goal is better domain modeling; when a
+straightforward fix would break another rule, restructure more deeply.
+
+### New section: "Workflow: fixing single-use type violations"
+
+Prioritized steps:
+
+1. **Delete unused code** — search for imports/call sites; delete if unused.
+   An export is only "public" if re-exported from an entry point; internal
+   exports with no callers are safe to delete.
+
+2. **Consider inlining the helper** — if single caller, consider inlining.
+   May make caller too large temporarily, but can then re-extract at a better
+   boundary. Keep if 2+ callers or complex logic. If exported, check whether
+   it's truly public API (re-exported from entry point) or just internal.
+
+3. **Consolidate types across boundaries** — shared types via intersection
+   (`&`), reuse state types instead of duplicating fields.
+
+4. **Other strategies** — nest subdomains, combine pipelines, unify parallel
+   structures, check external packages.
+
+### Existing "When you see" sections
+
+Keep as-is. Add a note that patterns are ordered by the workflow above.
+
+### New section: "Naming types"
+
+Name types after domain concepts, not functions. Avoid generic suffixes like
+`*Params`, `*Options`, `*Config`, `*Context`.
+
+### New section: "Check external packages for existing types"
+
+Check `node_modules/[package]/` for `.d.ts` files before creating type stubs.
+
+## Out of scope
+
+- The user's edge-case bug report about pipeline type detection — that's a
+  separate linter behavior issue, not a hints file concern
+- Changes to linter output or error messages
+- Changes to the linter's detection logic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forbid-junk-object-types",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "TypeScript linter that detects object types and interfaces used by only a single function",
   "main": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Add anti-inlining warning, "working with other linting rules" section, and prioritized workflow (DELETE → INLINE HELPER → CONSOLIDATE → OTHER) to `docs/fixing-violations.md`
- Add type naming guidance (domain concepts over generic suffixes) and external package type checking advice
- Based on user feedback: they needed ~20KB of supplemental CLAUDE.md guidance to get Claude Code to fix violations correctly

## Test plan

- [x] All 40 tests pass
- [ ] Verify the expanded doc reads well end-to-end
- [ ] Test with Claude Code on a codebase with violations to confirm improved behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)