### PR TITLE
Add Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+# Version updates for the actions pinned in workflows. npm security fixes
+# come from Dependabot security updates (a repo setting, no config here).
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Weekly version updates for the actions pinned in workflows. npm security-fix PRs come from the repo-level Dependabot security updates setting, enabled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)